### PR TITLE
fix Os.current wrong on mac.

### DIFF
--- a/src/main/java/com/github/kr328/gradle/golang/GoVariant.java
+++ b/src/main/java/com/github/kr328/gradle/golang/GoVariant.java
@@ -76,7 +76,7 @@ public class GoVariant implements Serializable {
                 current = Windows;
             } else if (osName.contains("linux")) {
                 current = Linux;
-            } else if (osName.contains("macos") || osName.contains("osx") || osName.contains("darwin")) {
+            } else if (osName.contains("mac") || osName.contains("os x") || osName.contains("darwin")) {
                 current = Darwin;
             } else {
                 current = Linux;


### PR DESCRIPTION
System.getProperty("os.name") will return "Mac OS X" on mac.